### PR TITLE
Fix README agent metadata inconsistencies and add validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This repository provides production-ready subagents that extend Claude Code's ca
 |-------|-------|-------------|
 | [backend-architect](backend-architect.md) | opus | RESTful API design, microservice boundaries, database schemas |
 | [frontend-developer](frontend-developer.md) | sonnet | React components, responsive layouts, client-side state management |
-| [graphql-architect](graphql-architect.md) | opus | GraphQL schemas, resolvers, federation architecture |
-| [architect-reviewer](architect-review.md) | opus | Architectural consistency analysis and pattern validation |
+| [graphql-architect](graphql-architect.md) | sonnet | GraphQL schemas, resolvers, federation architecture |
+| [architect-review](architect-review.md) | sonnet | Architectural consistency analysis and pattern validation |
 | [cloud-architect](cloud-architect.md) | opus | AWS/Azure/GCP infrastructure design and cost optimization |
 | [hybrid-cloud-architect](hybrid-cloud-architect.md) | opus | Multi-cloud strategies across cloud and on-premises environments |
 | [kubernetes-architect](kubernetes-architect.md) | opus | Cloud-native infrastructure with Kubernetes and GitOps |
@@ -112,14 +112,14 @@ This repository provides production-ready subagents that extend Claude Code's ca
 | [backend-security-coder](backend-security-coder.md) | opus | Secure backend coding practices, API security implementation |
 | [frontend-security-coder](frontend-security-coder.md) | opus | XSS prevention, CSP implementation, client-side security |
 | [mobile-security-coder](mobile-security-coder.md) | opus | Mobile security patterns, WebView security, biometric auth |
-| [architect-reviewer](architect-review.md) | opus | Architectural consistency and pattern validation |
+| [architect-review](architect-review.md) | sonnet | Architectural consistency and pattern validation |
 
 #### Testing & Debugging
 
 | Agent | Model | Description |
 |-------|-------|-------------|
 | [test-automator](test-automator.md) | sonnet | Comprehensive test suite creation (unit, integration, e2e) |
-| [tdd-orchestrator](tdd-orchestrator.md) | sonnet | Test-Driven Development methodology guidance |
+| [tdd-orchestrator](tdd-orchestrator.md) | opus | Test-Driven Development methodology guidance |
 | [debugger](debugger.md) | sonnet | Error resolution and test failure analysis |
 | [error-detective](error-detective.md) | sonnet | Log analysis and error pattern recognition |
 
@@ -155,7 +155,7 @@ This repository provides production-ready subagents that extend Claude Code's ca
 | [docs-architect](docs-architect.md) | opus | Comprehensive technical documentation generation |
 | [api-documenter](api-documenter.md) | sonnet | OpenAPI/Swagger specifications and developer docs |
 | [reference-builder](reference-builder.md) | haiku | Technical references and API documentation |
-| [tutorial-engineer](tutorial-engineer.md) | sonnet | Step-by-step tutorials and educational content |
+| [tutorial-engineer](tutorial-engineer.md) | opus | Step-by-step tutorials and educational content |
 | [mermaid-expert](mermaid-expert.md) | sonnet | Diagram creation (flowcharts, sequences, ERDs) |
 
 ### Business & Operations
@@ -166,7 +166,7 @@ This repository provides production-ready subagents that extend Claude Code's ca
 |-------|-------|-------------|
 | [business-analyst](business-analyst.md) | sonnet | Metrics analysis, reporting, KPI tracking |
 | [quant-analyst](quant-analyst.md) | opus | Financial modeling, trading strategies, market analysis |
-| [risk-manager](risk-manager.md) | sonnet | Portfolio risk monitoring and management |
+| [risk-manager](risk-manager.md) | opus | Portfolio risk monitoring and management |
 
 #### Marketing & Sales
 
@@ -241,7 +241,7 @@ Agents are assigned to specific Claude models based on task complexity and compu
 
 | Category | Count | Agents |
 |----------|-------|--------|
-| Architecture & Design | 7 | `architect-reviewer`, `backend-architect`, `cloud-architect`, `hybrid-cloud-architect`, `kubernetes-architect`, `graphql-architect`, `terraform-specialist` |
+| Architecture & Design | 7 | `architect-review`, `backend-architect`, `cloud-architect`, `hybrid-cloud-architect`, `kubernetes-architect`, `graphql-architect`, `terraform-specialist` |
 | Critical Analysis | 5 | `code-reviewer`, `security-auditor`, `performance-engineer`, `incident-responder`, `database-optimizer` |
 | AI/ML Complex | 5 | `ai-engineer`, `ml-engineer`, `mlops-engineer`, `data-scientist`, `prompt-engineer` |
 | Business Critical | 4 | `docs-architect`, `hr-pro`, `legal-advisor`, `quant-analyst` |
@@ -417,7 +417,7 @@ payment-integration → security-auditor → Validated implementation
 | API Design | `backend-architect` | RESTful APIs, microservices, database schemas |
 | Cloud Infrastructure | `cloud-architect` | AWS/Azure/GCP design, scalability planning |
 | UI/UX Design | `ui-ux-designer` | Interface design, wireframes, design systems |
-| System Architecture | `architect-reviewer` | Pattern validation, consistency analysis |
+| System Architecture | `architect-review` | Pattern validation, consistency analysis |
 
 ### Development by Language
 

--- a/examples/tdd-usage.md
+++ b/examples/tdd-usage.md
@@ -160,56 +160,52 @@ Prompt: "Write end-to-end tests for complete calculation workflow"
 
 ```bash
 Use Task tool with subagent_type="tdd-orchestrator"
-Prompt: "
-Develop REST API for blog platform with TDD:
-1. Start with OpenAPI spec
-2. Generate contract tests from spec
-3. Implement endpoints test-first
-4. Add integration tests
-5. Include performance tests
-"
+Prompt: |
+  Develop REST API for blog platform with TDD:
+  1. Start with OpenAPI spec
+  2. Generate contract tests from spec
+  3. Implement endpoints test-first
+  4. Add integration tests
+  5. Include performance tests
 ```
 
 ### Microservices TDD
 
 ```bash
 Use Task tool with subagent_type="tdd-orchestrator"
-Prompt: "
-Build microservice with TDD approach:
-- Contract tests for API
-- Unit tests for business logic
-- Integration tests for database
-- Component tests for service
-- End-to-end tests for workflows
-"
+Prompt: |
+  Build microservice with TDD approach:
+  - Contract tests for API
+  - Unit tests for business logic
+  - Integration tests for database
+  - Component tests for service
+  - End-to-end tests for workflows
 ```
 
 ### Frontend Component TDD
 
 ```bash
 Use Task tool with subagent_type="frontend-developer"
-Prompt: "
-Build date picker component with TDD:
-1. Test component renders
-2. Test date selection
-3. Test keyboard navigation
-4. Test accessibility
-5. Test date validation
-All tests first, then implementation
-"
+Prompt: |
+  Build date picker component with TDD:
+  1. Test component renders
+  2. Test date selection
+  3. Test keyboard navigation
+  4. Test accessibility
+  5. Test date validation
+  All tests first, then implementation
 ```
 
 ### Database Migration TDD
 
 ```bash
 Use Task tool with subagent_type="database-optimizer"
-Prompt: "
-Perform database migration with TDD:
-1. Write tests for current schema behavior
-2. Write tests for desired schema behavior
-3. Implement migration to pass both
-4. Include rollback tests
-"
+Prompt: |
+  Perform database migration with TDD:
+  1. Write tests for current schema behavior
+  2. Write tests for desired schema behavior
+  3. Implement migration to pass both
+  4. Include rollback tests
 ```
 
 ## TDD Anti-Pattern Detection

--- a/tests/test_readme_metadata.py
+++ b/tests/test_readme_metadata.py
@@ -1,0 +1,45 @@
+import re
+import pathlib
+
+import yaml
+
+
+README_PATH = pathlib.Path('README.md')
+AGENT_PATTERN = re.compile(r"\| \[(?P<label>[^\]]+)\]\((?P<path>[^)]+)\) \| (?P<model>[^|]+?) \|")
+
+
+def extract_agents_from_readme():
+    text = README_PATH.read_text()
+    agents = {}
+    for match in AGENT_PATTERN.finditer(text):
+        label = match.group('label').strip()
+        path = pathlib.Path(match.group('path').strip())
+        model = match.group('model').strip()
+        agents[label] = (path, model)
+    return agents
+
+
+def load_frontmatter(path: pathlib.Path) -> dict:
+    content = path.read_text()
+    segments = content.split('---', 2)
+    if len(segments) < 3:
+        raise AssertionError(f"{path} is missing YAML frontmatter")
+    data = yaml.safe_load(segments[1])
+    if not isinstance(data, dict):
+        raise AssertionError(f"{path} frontmatter is not a mapping")
+    return data
+
+
+def test_readme_agent_metadata_matches_files():
+    agents = extract_agents_from_readme()
+    assert agents, "No agents found in README tables"
+
+    for label, (path, model) in agents.items():
+        assert path.exists(), f"README references missing agent file: {path}"
+        data = load_frontmatter(path)
+        assert data.get('name') == label, (
+            f"README label '{label}' does not match agent name '{data.get('name')}'"
+        )
+        assert data.get('model') == model, (
+            f"README model for '{label}' is '{model}' but file specifies '{data.get('model')}'"
+        )


### PR DESCRIPTION
## Summary
- corrected README tables to use the documented agent names and models for graphql-architect, architect-review, tdd-orchestrator, tutorial-engineer, and risk-manager
- cleaned up multi-line prompts in the TDD usage example so they render correctly
- added a README metadata test to ensure table entries stay aligned with agent frontmatter

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8eedf16c832fb5920943a3fa6c19